### PR TITLE
getAssets()['asset'].path gives path instead of filename

### DIFF
--- a/src/internal/runtime.js
+++ b/src/internal/runtime.js
@@ -27,7 +27,7 @@ function getAssets() {
   const assets = {};
   for (const path of files) {
     const filename = basename(path);
-    assets[filename] = { path };
+    assets[filename] = { path: ASSETS_PATH+'/'+filename };
   }
   debug('Found the following assets available: %O', assets);
   return assets;


### PR DESCRIPTION
I'm not sure if this is the best way to fix that issue, but it seemed to do the job for me.