### PR TITLE
Merge .env variables into process.env

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -14,6 +14,7 @@ async function run() {
   const config = await getConfigFromCli(cli);
   debug('Determined configuration: %o', config);
   process.title = config.appName;
+  process.env = { ...process.env, ...config.env }
 
   if (config.inspect) {
     debug(


### PR DESCRIPTION
Hi. 

Using twilio-run with `--env` option, I can use `ACCOUNT_SID` and `AUTH_TOKEN` variables in Twilio authorization.
However, I cannot use `.env` variables in my Functions. 

I'd like to use `.env` in my Functions.
How about merging `config.env` into `proess.env`? :smiley: